### PR TITLE
fix a crash and memory management

### DIFF
--- a/src/core/trainingset/xmmPhrase.cpp
+++ b/src/core/trainingset/xmmPhrase.cpp
@@ -195,6 +195,11 @@ xmm::Phrase& xmm::Phrase::operator=(Phrase const& src) {
                               src.data_[1] + max_length_ * modality_dim,
                               data_[1]);
                 }
+            } else {
+                data_[0] = NULL;
+                if (bimodal_) {
+                    data_[1] = NULL;
+                }
             }
         } else {
             data_[0] = src.data_[0];
@@ -569,9 +574,9 @@ void xmm::Phrase::onAttributeChange(xmm::AttributeBase* attr_pointer) {
         data_[0] = nullptr;
         if (bimodal_) {
             if (own_memory_) {
-                data_[1] = nullptr;
+                delete data_[1];
             }
-            delete data_[1];
+            data_[1] = nullptr;
         }
         column_names.resize(dimension.get());
     }


### PR DESCRIPTION
- Added missing data_[X]= NULL initialization in the operator= constructor. Without this, xmm crashes in the RapidMixAPI library.
- Fixed a possible memory leak in onAttributeChange in the same file, where a pointer was nulled and then deleted instead of vice versa.